### PR TITLE
Fix module name format for rule generation path

### DIFF
--- a/chefboost/training/Training.py
+++ b/chefboost/training/Training.py
@@ -707,7 +707,7 @@ def buildDecisionTree(
         ):
             # this is reguler decision tree. find accuracy here.
 
-            module_name = "outputs/rules/rules"
+            module_name = "outputs.rules.rules"
             myrules = load_module(module_name)  # rules0
             models.append(myrules)
 

--- a/chefboost/training/Training.py
+++ b/chefboost/training/Training.py
@@ -735,7 +735,7 @@ def reconstructRules(source: str, feature_names, tree_id: int = 0) -> None:
     constructor = "def findDecision(obj): #"
     idx = 0
     for feature in feature_names:
-        constructor = constructor + "obj[" + str(idx) + "]: " + feature
+        constructor = constructor + "obj.iloc[" + str(idx) + "]: " + feature
 
         if idx < len(feature_names) - 1:
             constructor = constructor + ", "


### PR DESCRIPTION
### Summary
This PR corrects the `module_name` format in the rule generation path.

### Change Details
- Updated `module_name = "outputs/rules/rules"` to `module_name = "outputs.rules.rules"` for compatibility with Python's import system.

### Motivation
This change ensures that modules are correctly recognized as packages, avoiding potential import errors.

### Related Issue
Resolves #59 (if applicable)

### Testing
Manually tested to confirm that rule generation works as expected with the updated path.

### Checklist
- [x] Change has been tested locally