### PR TITLE
module not found error for python 3.9 sorted

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: [3.9]
 
     steps:
     - uses: actions/checkout@v3
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: [3.9]
   
     steps:
     - uses: actions/checkout@v3

--- a/chefboost/commons/module.py
+++ b/chefboost/commons/module.py
@@ -12,10 +12,10 @@ def load_module(module_name: str) -> ModuleType:
     Returns:
         module (ModuleType)
     """
-    if sys.version_info >= (3, 11):
+    if sys.version_info >= (3, 9):
         import importlib.util
 
-        spec = importlib.util.find_spec(module_name)
+        spec = importlib.util.find_spec(module_name.replace("/", "."))
         if spec is None:
             raise ImportError(f"Module '{module_name}' not found")
 

--- a/chefboost/training/Training.py
+++ b/chefboost/training/Training.py
@@ -557,7 +557,10 @@ def buildDecisionTree(
     # ---------------------------
     # add else condition in the decision tree
     if df.Decision.dtypes == "object":  # classification
-        pivot = pd.DataFrame(df.Decision.value_counts()).sort_values(by=["count"], ascending=False)
+        # value_counts return count label in 3.8, and Decision label in 3.9
+        df_summary = pd.DataFrame(df.Decision.value_counts())
+        count_label = df_summary.columns[0]
+        pivot = df_summary.sort_values(by=[count_label], ascending=False)
         else_decision = f"return '{str(pivot.iloc[0].name)}'"
 
         if enableParallelism != True:


### PR DESCRIPTION
# Tickets

Resolves https://github.com/serengil/chefboost/issues/59

# What has been done

While loading modules dynamically, we were using slashes until python 3.8. However, python expects dot instead of slash for python 3.9 and later.

# How to test

```shell
make test
```