### PR TITLE
fix: replace dtype=='object' checks with pd.api.types.is_numeric_dtype() for pandas 3.x compatibility

### DIFF
--- a/chefboost/Chefboost.py
+++ b/chefboost/Chefboost.py
@@ -96,7 +96,7 @@ def fit(
     nan_values = []
 
     for column in df.columns:
-        if df[column].dtypes != "object":
+        if pd.api.types.is_numeric_dtype(df[column]):
             min_value = df[column].min()
             idx = df[df[column].isna()].index
 
@@ -154,19 +154,18 @@ def fit(
     num_of_columns = df.shape[1]
 
     if algorithm == "Regression":
-        if df["Decision"].dtypes == "object":
+        if not pd.api.types.is_numeric_dtype(df["Decision"]):
             raise ValueError(
                 "Regression trees cannot be applied for nominal target values!"
                 "You can either change the algorithm or data set."
             )
 
-    if (
-        df["Decision"].dtypes != "object"
-    ):  # this must be regression tree even if it is not mentioned in algorithm
+    if pd.api.types.is_numeric_dtype(
+        df["Decision"]):  # this must be regression tree even if it is not mentioned in algorithm
         if algorithm != "Regression":
             logger.warn(
                 f"You set the algorithm to {algorithm} but the Decision column of your"
-                " data set has non-object type."
+                " data set has numeric type."
                 "That's why, the algorithm is set to Regression to handle the data set."
             )
 
@@ -183,7 +182,7 @@ def fit(
         # enableParallelism = False
         for j in range(0, num_of_columns):
             column_name = df.columns[j]
-            if df[column_name].dtypes == "object":
+            if not pd.api.types.is_numeric_dtype(df[column_name]):
                 raise ValueError(
                     "Adaboost must be run on numeric data set for both features and target"
                 )
@@ -229,7 +228,8 @@ def fit(
         )
 
     elif enableGBM == True:
-        if df["Decision"].dtypes == "object":  # transform classification problem to regression
+        if not pd.api.types.is_numeric_dtype(df["Decision"]):
+            # transform classification problem to regression
             trees, alphas = gbm.classifier(
                 df,
                 config,

--- a/chefboost/training/Training.py
+++ b/chefboost/training/Training.py
@@ -137,7 +137,7 @@ def findGains(df: pd.DataFrame, config: dict) -> dict:
 
         logger.debug(f"{column_name} -> {column_type}")
 
-        if column_type != "object":
+        if pd.api.types.is_numeric_dtype(column_type):
             df = Preprocess.processContinuousFeatures(algorithm, df, column_name, entropy, config)
 
         classes = df[column_name].value_counts()
@@ -474,7 +474,7 @@ def buildDecisionTree(
         j = j + 1
 
     numericColumn = False
-    if dataset_features[winner_name] != "object":
+    if pd.api.types.is_numeric_dtype(dataset_features[winner_name]):
         numericColumn = True
 
     # restoration
@@ -482,7 +482,7 @@ def buildDecisionTree(
     for i in range(0, columns - 1):
         column_name = df_copy.columns[i]
         column_type = df_copy[column_name].dtypes
-        if column_type != "object" and column_name != winner_name:
+        if pd.api.types.is_numeric_dtype(column_type) and column_name != winner_name:
             df[column_name] = df_copy[column_name]
 
     classes = df[winner_name].value_counts().keys().tolist()
@@ -556,7 +556,7 @@ def buildDecisionTree(
 
     # ---------------------------
     # add else condition in the decision tree
-    if df.Decision.dtypes == "object":  # classification
+    if not pd.api.types.is_numeric_dtype(df.Decision.dtype):  # classification
         # value_counts return count label in 3.8, and Decision label in 3.9
         df_summary = pd.DataFrame(df.Decision.value_counts())
         count_label = df_summary.columns[0]


### PR DESCRIPTION
## Summary

This PR fixes a compatibility issue that makes chefboost completely broken for 
classification tasks on **pandas 3.0+**.

Closes #62 

---

## Problem

In pandas 3.0+, string columns now return `dtype='str'` (the new `StringDtype`) 
instead of the old `dtype('O')` (object). This breaks all `dtype == "object"` 
comparisons throughout the codebase.

The cascade failure:
1. `Chefboost.py` line 164: `df["Decision"].dtypes != "object"` evaluates to
   `True` for string columns in pandas 3.x → algorithm silently overridden to
   `"Regression"`, ignoring the user's `algorithm='C4.5'` config
2. `Training.py` line 141: calls `Preprocess.processContinuousFeatures()`
   because algorithm is now wrongly set to `"Regression"`
```python
# pandas < 2.0:
pd.Series(['A', 'B']).dtype == 'object'  # True  ✅

# pandas 3.0+:
pd.Series(['A', 'B']).dtype == 'object'  # False ❌ — now returns 'str' (StringDtype)
```

---

## Fix

Replace all `dtype == "object"` / `dtype != "object"` checks with 
`pd.api.types.is_numeric_dtype()`, which correctly distinguishes numeric from 
categorical/string columns across **all pandas versions (1.x, 2.x, 3.x)**.

**Files changed:** `chefboost/Chefboost.py` (5 occurrences), 
`chefboost/training/Training.py` (4 occurrences) — 9 total.

---

## Testing

Verified working with:
- Python 3.12.3
- pandas 3.0.1 (previously broken)
- chefboost 0.0.19
```python
import pandas as pd
from chefboost import Chefboost as chef

df = pd.DataFrame({
    'Feature1': [1, 2, 3, 1, 2, 3, 1, 2],
    'Feature2': [4, 5, 4, 5, 4, 5, 4, 5],
    'Decision': ['A', 'B', 'A', 'B', 'A', 'A', 'B', 'B']
})

config = {'algorithm': 'C4.5'}
model = chef.fit(df, config=config, target_label='Decision')
# ✅ Now works correctly — no longer crashes or silently switches to Regression
```

The fix uses `pd.api.types.is_numeric_dtype()`, a pandas utility function 
available since pandas 0.20, ensuring full backward compatibility with 
older pandas versions as well.